### PR TITLE
Feature/world creation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ else
 	FLAGS	:= -Wextra -Wall -Werror -Wunreachable-code -Ofast -g3
 endif
 
+VALGRIND	:= valgrind -q --leak-check=full --show-leak-kinds=all --track-origins=yes
+
 #----------------------------------------------- Sources
 LIBFT_FOLDER	= lib/libft
 LIBMLX_FOLDER	= lib/MLX42
@@ -113,39 +115,39 @@ test: all \
 
 tests_tuples:
 	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_tuples.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 tests_colors:
 	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_colors.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 tests_matrix:
 	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_matrix.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 tests_transformation:
 	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_transformation.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 tests_ray_intersection:
 	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_ray_intersection.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 tests_light:
 	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_light.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 tests_world:
-	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_world.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(CC) $(FLAGS) $(HEADERS) $(TEST_FILES) tests/tests_world.c $(LIBS) -o $@
+	@$(VALGRIND) ./$@
 
 tests_camera:
 	@$(CC) $(FLAGS) $(HEADERS) $(TEST_FILES) tests/tests_camera.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 tests_shadows:
 	@$(CC) -g3 $(HEADERS) $(TEST_FILES) tests/tests_shadows.c $(LIBS) -o $@
-	@valgrind -q ./$@
+	@$(VALGRIND) ./$@
 
 pit: all
 #	@$(CC) $(FLAGS) $(HEADERS) $(shell find src -iname "*.c" ! -name "main.c") putting_it_together/projectiles.c $(LIBS) -o pit

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -312,5 +312,6 @@ void	add_light(t_light **light_list, t_light light_to_add);
 void	light_clear_list(t_light **light_list);
 t_comps	prepare_computations(t_hit hit, t_ray ray);
 t_color	shade_hit(t_world world, t_comps comps);
+t_color	color_at(t_world w, t_ray r);
 
 #endif

--- a/include/minirt.h
+++ b/include/minirt.h
@@ -305,13 +305,14 @@ int			float_compare(double d1, double d2);
 void		ft_error(char *message);
 
 // NÃO SEI ONDE POR
-void	add_shape(t_shape **shape_list, t_shape shape);
-void	world_clear(t_world *world_to_clear);
-void	shape_clear_list(t_shape **shape_list);
-void	add_light(t_light **light_list, t_light light_to_add);
-void	light_clear_list(t_light **light_list);
-t_comps	prepare_computations(t_hit hit, t_ray ray);
-t_color	shade_hit(t_world world, t_comps comps);
-t_color	color_at(t_world w, t_ray r);
+void		add_shape(t_shape **shape_list, t_shape shape);
+void		world_clear(t_world *world_to_clear);
+void		shape_clear_list(t_shape **shape_list);
+void		add_light(t_light **light_list, t_light light_to_add);
+void		light_clear_list(t_light **light_list);
+t_comps		prepare_computations(t_hit hit, t_ray ray);
+t_color		shade_hit(t_world world, t_comps comps);
+t_color		color_at(t_world w, t_ray r);
+t_matrix	view_transform(t_point from, t_point to, t_vector up);
 
 #endif

--- a/src/world.c
+++ b/src/world.c
@@ -120,3 +120,31 @@ t_color	color_at(t_world w, t_ray r)
 	}
 	return (color_at_hit);
 }
+
+t_matrix	view_transform(t_point from, t_point to, t_vector up)
+{
+	t_vector	forward;
+	t_vector	left;
+	t_vector	true_up;
+	t_matrix	orientation;
+	t_matrix	view_matrix;
+
+	forward = normalize(tuple_subtract(to, from));
+	left = cross(forward, normalize(up));
+	true_up = cross(left, forward);
+	orientation = identity();
+	mx_set(&orientation, 0, 0, left.x);
+	mx_set(&orientation, 0, 1, left.y);
+	mx_set(&orientation, 0, 2, left.z);
+	mx_set(&orientation, 1, 0, true_up.x);
+	mx_set(&orientation, 1, 1, true_up.y);
+	mx_set(&orientation, 1, 2, true_up.z);
+	mx_set(&orientation, 2, 0, -forward.x);
+	mx_set(&orientation, 2, 1, -forward.y);
+	mx_set(&orientation, 2, 2, -forward.z);
+	view_matrix = mx_multiply(
+		orientation,
+		translation(-from.x, -from.y, -from.z)
+	);
+	return (view_matrix);
+}

--- a/src/world.c
+++ b/src/world.c
@@ -68,6 +68,7 @@ t_comps	prepare_computations(t_hit hit, t_ray ray)
 	comps.point = position(ray, comps.t);
 	comps.sight.eye = tuple_negate(ray.direction);
 	comps.sight.normal = normal_at(comps.object, comps.point);
+	comps.sight.in_shadow = false;
 	if (dot(comps.sight.normal, comps.sight.eye) < 0)
 	{
 		comps.inside = true;
@@ -99,4 +100,23 @@ t_color	shade_hit(t_world world, t_comps comps)
 		aux = aux->next;
 	}
 	return (color_shaded);
+}
+
+t_color	color_at(t_world w, t_ray r)
+{
+	t_color	color_at_hit;
+	t_comps	comps;
+	t_hit	*nearest_hit;
+	t_hit	*hits;
+
+	color_at_hit = color(0, 0, 0);
+	hits = intersect_world(w, r);
+	nearest_hit = hit(hits);
+	if (nearest_hit)
+	{
+		comps = prepare_computations(*nearest_hit, r);
+		color_at_hit = shade_hit(w, comps);
+		hit_clear_list(&hits);
+	}
+	return (color_at_hit);
 }

--- a/tests/tests_utils_print.c
+++ b/tests/tests_utils_print.c
@@ -99,12 +99,12 @@ void	print_ko_matrix(int num_test, void *expected, void *result)
 	printf(PURPLE "%2d" RESET " - " RED "[ ✗ ] " RESET"\nExpected: ( ", num_test);
 	for (int i = 0; i < size_matrix; i++)
 		printf("%.2lf%s", matrix_expected->tab[i], i + 1 < size_matrix ? " " : "");
-	printf(")\n");
+	printf(" )\n");
 
 	printf("Result:   ( ");
 	for (int i = 0; i < size_matrix; i++)
 		printf("%.2lf%s", matrix_result->tab[i], i + 1 < size_matrix ? " " : "");
-	printf(")\n");
+	printf(" )\n");
 }
 
 void	print_ko_ray(int num_test, void *expected, void *result)

--- a/tests/tests_world.c
+++ b/tests/tests_world.c
@@ -261,21 +261,106 @@ void	test_color_at_with_intersection_behind_ray(int num_test)
 	world_clear(&w);
 }
 
+// TEST 12
+void	test_the_transformation_martix_for_the_default_orientation(int num_test)
+{
+	// ARRANGE
+	t_tuple		from = point(0, 0, 0);
+	t_tuple		to = point(0, 0, -1);
+	t_tuple		up = vector(0, 1, 0);
+	t_matrix	expected;
+	t_matrix	result;
+
+	expected = identity();
+
+	// ACT
+	result = view_transform(from, to, up);
+
+	// ASSERT
+	print_result(num_test, &expected, &result, matrix_compare_test, print_ko_matrix);
+}
+
+// TEST 13
+void	test_a_view_transformation_matrix_looking_in_positive_z_direction(int num_test)
+{
+	// ARRANGE
+	t_tuple		from = point(0, 0, 0);
+	t_tuple		to = point(0, 0, 1);
+	t_tuple		up = vector(0, 1, 0);
+	t_matrix	expected;
+	t_matrix	result;
+
+	expected = scaling(-1, 1, -1);
+
+	// ACT
+	result = view_transform(from, to, up);
+
+	// ASSERT
+	print_result(num_test, &expected, &result, matrix_compare_test, print_ko_matrix);
+}
+
+// TEST 14
+void	test_the_view_transformation_moves_the_world(int num_test)
+{
+	// ARRANGE
+	t_tuple		from = point(0, 0, 8);
+	t_tuple		to = point(0, 0, 0);
+	t_tuple		up = vector(0, 1, 0);
+	t_matrix	expected;
+	t_matrix	result;
+
+	expected = translation(0, 0, -8);
+
+	// ACT
+	result = view_transform(from, to, up);
+
+	// ASSERT
+	print_result(num_test, &expected, &result, matrix_compare_test, print_ko_matrix);
+}
+
+// TEST 15
+void	test_an_arbitrary_view_transformation(int num_test)
+{
+	// ARRANGE
+	double		tab[] = {
+		-0.50709, 0.50709,  0.67612, -2.36643,
+		 0.76772, 0.60609,  0.12122, -2.82843,
+		-0.35857, 0.59761, -0.71714,  0.00000,
+		 0.00000, 0.00000,  0.00000,  1.00000
+	};
+
+	t_tuple		from = point(1, 3, 2);
+	t_tuple		to = point(4, -2, 8);
+	t_tuple		up = vector(1, 1, 0);
+	t_matrix	expected = matrix_create(tab, 4, 4);
+	t_matrix	result;
+
+	// ACT
+	result = view_transform(from, to, up);
+
+	// ASSERT
+	print_result(num_test, &expected, &result, matrix_compare_test, print_ko_matrix);
+}
+
 int main(void)
 {
 	void	(*test_funcs[])(int) =
 	{
-		test_creating_a_world,										// 01
-		test_default_world,											// 02
-		test_intersect_a_world_with_a_ray,							// 03
-		test_precomputing_state_of_an_intersection,					// 04
-		test_the_hit_when_an_intersection_occurs_on_the_outside,	// 05
-		test_the_hit_when_an_intersection_occurs_on_the_inside,		// 06
-		test_shading_an_intersection,								// 07
-		test_shading_an_intersection_from_the_inside,				// 08
-		test_color_at_with_ray_misses,								// 09
-		test_color_at_with_ray_hits,								// 10
-		test_color_at_with_intersection_behind_ray,					// 11
+		test_creating_a_world,												// 01
+		test_default_world,													// 02
+		test_intersect_a_world_with_a_ray,									// 03
+		test_precomputing_state_of_an_intersection,							// 04
+		test_the_hit_when_an_intersection_occurs_on_the_outside,			// 05
+		test_the_hit_when_an_intersection_occurs_on_the_inside,				// 06
+		test_shading_an_intersection,										// 07
+		test_shading_an_intersection_from_the_inside,						// 08
+		test_color_at_with_ray_misses,										// 09
+		test_color_at_with_ray_hits,										// 10
+		test_color_at_with_intersection_behind_ray,							// 11
+		test_the_transformation_martix_for_the_default_orientation,			// 12
+		test_a_view_transformation_matrix_looking_in_positive_z_direction,	// 13
+		test_the_view_transformation_moves_the_world,						// 14
+		test_an_arbitrary_view_transformation,								// 15
 	};
 
 	printf("\n%sTESTING WORLD CREATION:%s\n", YELLOW, RESET);

--- a/tests/tests_world.c
+++ b/tests/tests_world.c
@@ -184,11 +184,75 @@ void	test_shading_an_intersection_from_the_inside(int num_test)
 
 	w.light->intensity = color(1, 1, 1);
 	w.light->position = point(0, 0.25, 0);
-	s.material.ambient = 1;
 	expected = color(0.90498, 0.90498, 0.90498);
 
 	// ACT
 	result = shade_hit(w, comps);
+
+	// ASSERT
+	print_result(num_test, &expected, &result, color_compare_test, print_ko_color);
+
+	// CLEAR
+	world_clear(&w);
+}
+
+// TEST 09
+void	test_color_at_with_ray_misses(int num_test)
+{
+	// ARRANGE
+	t_world	w = default_world();
+	t_ray	r = ray(point(0, 0, -5), vector(0, 1, 0));
+	t_color	expected;
+	t_color	result;
+
+	expected = color(0, 0, 0);
+
+	// ACT
+	result = color_at(w, r);
+
+	// ASSERT
+	print_result(num_test, &expected, &result, color_compare_test, print_ko_color);
+
+	// CLEAR
+	world_clear(&w);
+}
+
+// TEST 10
+void	test_color_at_with_ray_hits(int num_test)
+{
+	// ARRANGE
+	t_world	w = default_world();
+	t_ray	r = ray(point(0, 0, -5), vector(0, 0, 1));
+	t_color	expected;
+	t_color	result;
+
+	expected = color(0.38066, 0.47583, 0.2855);
+
+	// ACT
+	result = color_at(w, r);
+
+	// ASSERT
+	print_result(num_test, &expected, &result, color_compare_test, print_ko_color);
+
+	// CLEAR
+	world_clear(&w);
+}
+
+// TEST 11
+void	test_color_at_with_intersection_behind_ray(int num_test)
+{
+	// ARRANGE
+	t_world	w = default_world();
+	t_ray	r = ray(point(0, 0, 0.75), vector(0, 0, -1));
+	t_color	expected;
+	t_color	result;
+
+	w.shape->material.ambient = 1;
+	w.shape->next->material.ambient = 1;
+	expected = w.shape->next->material.color;
+
+	// ACT
+	result = color_at(w, r);
 
 	// ASSERT
 	print_result(num_test, &expected, &result, color_compare_test, print_ko_color);
@@ -209,6 +273,9 @@ int main(void)
 		test_the_hit_when_an_intersection_occurs_on_the_inside,		// 06
 		test_shading_an_intersection,								// 07
 		test_shading_an_intersection_from_the_inside,				// 08
+		test_color_at_with_ray_misses,								// 09
+		test_color_at_with_ray_hits,								// 10
+		test_color_at_with_intersection_behind_ray,					// 11
 	};
 
 	printf("\n%sTESTING WORLD CREATION:%s\n", YELLOW, RESET);


### PR DESCRIPTION
This pull request includes several changes to the `Makefile`, the `minirt` project source files, and test files to add new functionalities and improve the testing process. The most important changes include adding new utility functions, updating the `Makefile` to use a variable for `valgrind`, and adding new test cases for the newly introduced functions.

### Makefile improvements:

* Added `VALGRIND` variable to simplify `valgrind` command usage across multiple test targets in the `Makefile`. (`Makefile`, [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R35-R36) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L116-R150)

### New utility functions:

* Added `color_at` and `view_transform` functions to `src/world.c` for handling color calculations and view transformations. (`src/world.c`, [src/world.cR104-R150](diffhunk://#diff-6987e9c2dc487ffd3cef54a542070a1c3e8d92d6da18e59966cc89db0ea1aeedR104-R150))
* Updated `include/minirt.h` to declare the new `color_at` and `view_transform` functions. (`include/minirt.h`, [include/minirt.hR315-R316](diffhunk://#diff-aa8bff8e214ca5a9fcf7d483a0d202122869c9bec85eee174a3424323dfbc6edR315-R316))

### Test enhancements:

* Added new test cases to `tests/tests_world.c` for the `color_at` and `view_transform` functions, including scenarios for ray misses, ray hits, intersections behind the ray, and various view transformations. (`tests/tests_world.c`, [[1]](diffhunk://#diff-a3710ca5cdf1015fe4a788838411a9536f71f2fbf14774c344004419911cc08aR199-R344) [[2]](diffhunk://#diff-a3710ca5cdf1015fe4a788838411a9536f71f2fbf14774c344004419911cc08aR357-R363)
* Removed an unnecessary assignment in the `test_shading_an_intersection_from_the_inside` function to clean up the test code. (`tests/tests_world.c`, [tests/tests_world.cL187](diffhunk://#diff-a3710ca5cdf1015fe4a788838411a9536f71f2fbf14774c344004419911cc08aL187))