### PR TITLE
FEATURE: mlx working

### DIFF
--- a/include/minirt.h
+++ b/include/minirt.h
@@ -29,11 +29,12 @@
 # define BLINK  "\001\033[5m\002"
 # define REVERSE "\001\033[7m\002"
 
-# define EPSILON 0.00001
-# define NUM_THREADS 4
+# define EPSILON        0.00001
+# define NUM_THREADS    4
+/*mudar aqui para 3 dps*/# define PIXEL_SAMPLING 1
 
-# define WIDTH 1920
-# define HEIGH 1080
+# define WIDTH 1000
+# define HEIGH 1000
 
 # include <stdio.h>
 # include <stdlib.h>
@@ -487,7 +488,7 @@ bool		parse_brightness(char *splitted, double *brightness);
 bool		parse_color(char *splitted, t_color *new_color);
 bool		parse_sphere(char *line, t_world *world);
 bool		parse_plane(char *line, t_world *world);
-bool		parse_normal(char *splitted, t_vector *normal);
+// bool		parse_normal(char *splitted, t_vector *normal);
 bool		parse_cylinder(char *line, t_world *world);
 bool		parse_cone(char *line, t_world *world);
 bool		parse_camera(char *line, t_world *world);
@@ -502,9 +503,12 @@ int			almost_zero(float num);
 void		swap(double *a, double *b);
 void		join_threads(pthread_t *threads, int thread_count);
 float		fternary(int condition, float if_true, float if_false);
+void		check_extension(char *filename);
+void		canvas_to_ppm(t_canvas canvas, char *filename);
+char		*get_file_name(char *file_name_base);
 
 // parser
-bool		is_all_numbers(char **split);
+// bool		is_all_numbers(char **split);
 bool		validate_count(char **split, int count);
 // bool		validate_color_range(char **str);
 // bool		validate_normal_range(char **str);
@@ -620,7 +624,12 @@ t_color		uv_pattern_at(t_checkers checkers, double u, double v);
 void		spherical_map(t_point point, double *u, double *v);
 t_map		texture_map(t_checkers checkers, void (*map_fn)(t_point, double *, double *));
 void		cylindrical_map(t_point point, double *u, double *v);
-uint8_t		*get_pixel(mlx_texture_t *texture, int x, int y);
-t_color		texture_at_shape(t_shape object, t_point point);
+// uint8_t		*get_pixel(mlx_texture_t *texture, int x, int y);
+// t_color		texture_at_shape(t_shape object, t_point point);
+
+// mlx
+void		key_hook(mlx_key_data_t keydata, void *param);
+void		start_render(t_world world, int save_to_file, char *file_name);
+
 
 #endif

--- a/src/canvas/utils.c
+++ b/src/canvas/utils.c
@@ -1,0 +1,40 @@
+#include "minirt.h"
+
+void print_ppm_header(int width, int height, int fd)
+{
+	// dprintf - mais uma função que não poderia usar, mas o bônus deixa
+	dprintf(fd, "P3\n%d %d\n255\n", width, height);
+}
+
+void print_line_ppm(t_color pixel, int fd)
+{
+	dprintf(fd, "%d %d %d ", (int)(pixel.r * 255), (int)(pixel.g * 255), (int)(pixel.b * 255));
+}
+
+void	canvas_to_ppm(t_canvas canvas, char *filename)
+{
+	int		y;
+	int		x;
+	int		fd;
+
+	fd = open(filename, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+	if (fd < 0)
+	{
+		perror(filename);
+		return ;
+	}
+	print_ppm_header(canvas.width, canvas.height, fd);
+	y = 0;
+	while (y < canvas.height)
+	{
+		x = 0;
+		print_rendering_progress(canvas.width, canvas.height, y);
+		while (x < canvas.width)
+		{
+			print_line_ppm(pixel_at(canvas, x, y), fd);
+			x++;
+		}
+		y++;
+	}
+	close(fd);
+}

--- a/src/main.c
+++ b/src/main.c
@@ -12,87 +12,21 @@
 
 #include "minirt.h"
 
-void	check_extension(char *filename)
-{
-	char	*extension;
-	bool	ok;
-
-	ok = 1;
-	extension = ft_strrchr(filename, '.') + 1;
-	if (!extension)
-		ok = 0;
-	if (ft_strncmp(extension, "rt", 2) != 0)
-		ok = 0;
-	if (ok == 0)
-	{
-		ft_error("Invalid file extension\n");
-		exit(EXIT_FAILURE);
-	}
-}
-
-void	canvas_to_ppm(t_canvas canvas, char *filename)
-{
-	FILE	*file = fopen(filename, "w");
-
-	if (!file)
-	{
-		perror(filename);
-		return ;
-	}
-
-	fprintf(file, "P3\n%d %d\n255\n", canvas.width, canvas.height);
-	for (int y = 0; y < canvas.height; y++)
-	{
-		for (int x = 0; x < canvas.width; x++)
-		{
-			t_color	pixel = pixel_at(canvas, x, y);
-			int		r = (int)(pixel.r * 255);
-			int		g = (int)(pixel.g * 255);
-			int		b = (int)(pixel.b * 255);
-
-			fprintf(file, "%d %d %d\n", r, g, b);
-		}
-	}
-	fclose(file);
-}
-
-void	test_rendering(t_world world)
-{
-	// t_shape	pl = plane();
-	// pl.material.color = color(1, 0, 0);
-	// set_transformation(&pl, translation(0, 0, 0));
-	// add_shape(&world.shape, pl);
-
-	// t_light	light1 = point_light(point(0, 20, -10), color(1, 1, 1));
-	// add_light(&world.light, light1);
-
-	world.scene.pixel_sampling = 1;
-
-	(void)!write(STDOUT_FILENO, "\033[s", 4);
-
-	t_canvas	canvas = render(world.scene.world_camera, world);
-
-	canvas_to_ppm(canvas, "test_rotation.ppm");
-	free(canvas.pixels);
-
-	(void)!write(STDOUT_FILENO, "\n", 1);
-}
-
 int	main(int argc, char **argv)
 {
 	int		fd;
+	int		save_to_file;
 	t_world	new_world;
 
-	if (argc != 2)
+	if (!(argc == 2 || argc == 3))
 	{
-		ft_error("Usage: ./miniRT [scene.rt]\n");
+		ft_error("Usage: ./miniRT [scene.rt] (--save-to-file)\n");
 		return (1);
 	}
 	check_extension(argv[1]);
 	new_world = world();
 	fd = open(argv[1], O_RDONLY);
 
-	// só para testes
 	if (fd < 0)
 		perror(argv[1]);
 
@@ -100,45 +34,16 @@ int	main(int argc, char **argv)
 		ft_error("Invalid map\n");
 	else
 	{
-		test_rendering(new_world);
+		if (argv[2])
+			save_to_file = ft_strncmp("--save-to-file", argv[2], -1) == 0;
+		else
+			save_to_file = 0;
+		start_render(new_world, save_to_file, get_file_name(argv[1]));
 	}
-	close(fd);
-
-	(void)!write(STDOUT_FILENO, "\033[s", 4);
+	if (fd != -1)
+		close(fd);
 
 	world_clear(&new_world);
 
 	return (0);
 }
-
-
-/*
-# The Basic Shapes 01
-
-# Ambient Light
-# <intensity: 0-1> <color: red, green, blue>
-A   0.2                     255,255,255
-# Camera
-# <coordinates of camera position: x,y,z> <camera view: x,y,z> <pov:x,y,z>
-C            -50,0,20                         0,0,0                70
-
-## Error
-## K    -40,0,30                  0.7           255,255,255
-
-# Light
-# <coordinates: x,y,z> <brightness: 0-1> <color:red,green,blue>
-L     -40,0,30              0.7                255,255,255
-
-# Plane
-# <coordinates: x,y,z> <normal: x,y,z> <color:red,green,blue>
-pl  0,0,0                0,1.0,0           255,0,225
-
-# Sphere
-# <coordinates: x,y,z> <diameter> <color:red,green,blue>
-sp  0,0,20                20             255,0,0
-
-#Cylinder
-# <coordinates: x,y,z> <normal: x,y,z> <diameter> <height> <color:red,green,blue>
-cy  50.0,0.0,20.6         0,0,1.0        14.2       21.42          10,0,255
-
-*/

--- a/src/mlx/mlx.c
+++ b/src/mlx/mlx.c
@@ -1,0 +1,37 @@
+#include "minirt.h"
+
+void	key_hook(mlx_key_data_t keydata, void *param)
+{
+	mlx_t	*mlx;
+
+	mlx = param;
+	if (keydata.key == MLX_KEY_ESCAPE)
+		mlx_close_window(mlx);
+}
+
+void	start_render(t_world world, int save_to_file, char *file_name)
+{
+	t_canvas	canvas;
+	mlx_t		*mlx;
+	mlx_image_t	*image;
+
+	(void)!write(STDOUT_FILENO, "\033[s", 4);
+	canvas = render(world.scene.world_camera, world);
+	(void)!write(STDOUT_FILENO, "\n", 1);
+	mlx_set_setting(MLX_STRETCH_IMAGE, true);
+	mlx = mlx_init(WIDTH, HEIGH, "miniRT", true);
+	image = canvas_to_image(canvas, mlx);
+	mlx_image_to_window(mlx, image, 0, 0);
+	mlx_key_hook(mlx, key_hook, mlx);
+	mlx_loop(mlx);
+	mlx_delete_image(mlx, image);
+	mlx_terminate(mlx);
+	if (save_to_file)
+	{
+		(void)!write(STDOUT_FILENO, "Saving:\n\033[s", 12);
+		canvas_to_ppm(canvas, file_name);
+		(void)!write(STDOUT_FILENO, "\n", 1);
+	}
+	free(canvas.pixels);
+	free(file_name);
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -37,7 +37,6 @@ void	ft_error(char *message)
 	ft_putstr_fd(ORANGE, 2);
 	ft_putstr_fd(message, 2);
 	ft_putstr_fd(RESET, 2);
-	// exit(EXIT_FAILURE);
 }
 
 int	almost_zero(float num)
@@ -52,4 +51,34 @@ void	swap(double *a, double *b)
 	tmp = *a;
 	*a = *b;
 	*b = tmp;
+}
+
+void	check_extension(char *filename)
+{
+	char	*extension;
+	bool	ok;
+
+	ok = 1;
+	extension = ft_strrchr(filename, '.') + 1;
+	if (!extension)
+		ok = 0;
+	if (ft_strncmp(extension, "rt", 2) != 0)
+		ok = 0;
+	if (ok == 0)
+	{
+		ft_error("Invalid file extension\n");
+		exit(EXIT_FAILURE);
+	}
+}
+
+char	*get_file_name(char *file_name_base)
+{
+	char	*file_name;
+	char	*new_name;
+
+	file_name = ft_strdup(file_name_base);
+	ft_strrchr(file_name, '.')[0] = '\0';
+	new_name = ft_strjoin(file_name, ".ppm");
+	free(file_name);
+	return (new_name);
 }

--- a/src/world/world.c
+++ b/src/world/world.c
@@ -21,7 +21,7 @@ t_world	world(void)
 			.ambient_color = color(1, 1, 1),
 			.ambient_ratio = 0.1,
 			.world_camera = {0},
-			.pixel_sampling = 1,
+			.pixel_sampling = PIXEL_SAMPLING,
 			.has_ambient_color = 0,
 			.has_camera = 0,
 			.pattern_list = NULL,

--- a/supp.supp
+++ b/supp.supp
@@ -1,0 +1,64 @@
+{
+   <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:_dl_catch_exception
+   ...
+}
+{
+ <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:mlx_init
+   ...
+}
+{
+ <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:XrmGetStringDatabase
+   ...
+}
+{
+ <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:_XrmInitParseInfo
+   ...
+}
+{
+ <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:__tls_get_addr
+   ...
+}
+{
+ <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:__pthread_once_slow
+   ...
+}
+{
+ <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:glfwInit
+   ...
+}
+{
+ <MLX_CODAM>
+   Memcheck:Leak
+   match-leak-kinds: reachable
+   ...
+   fun:_dl_init
+   ...
+}


### PR DESCRIPTION
This pull request includes several changes to the `minirt` project, focusing on rendering functionality, file handling, and code cleanup. The most important changes involve the addition of new rendering functions, modifications to the main program flow, and the removal of deprecated code.

### Rendering Enhancements:

* Added new rendering functions `canvas_to_ppm`, `key_hook`, and `start_render` to improve the rendering process and handle user interactions. (`src/canvas/utils.c`, `src/mlx/mlx.c`) [[1]](diffhunk://#diff-e7f1140482394ed651f4534394dc5be73d22ac33861104b952d55fbe89a0c3e9R1-R40) [[2]](diffhunk://#diff-bb4860ef942a83386fef0aa3b84b730af496a70af8c9ee5a7e13a31b28944e6eR1-R37)

### Main Program Modifications:

* Updated the main program to handle an optional `--save-to-file` argument, which allows saving the rendered image to a file. (`src/main.c`)
* Moved the `check_extension` function to `src/utils.c` and added a new `get_file_name` function for generating file names. (`src/utils.c`)

### Code Cleanup:

* Commented out deprecated or unused functions such as `parse_normal`, `is_all_numbers`, and texture-related functions. (`include/minirt.h`) [[1]](diffhunk://#diff-aa8bff8e214ca5a9fcf7d483a0d202122869c9bec85eee174a3424323dfbc6edL490-R491) [[2]](diffhunk://#diff-aa8bff8e214ca5a9fcf7d483a0d202122869c9bec85eee174a3424323dfbc6edR506-R511) [[3]](diffhunk://#diff-aa8bff8e214ca5a9fcf7d483a0d202122869c9bec85eee174a3424323dfbc6edL623-R633)
* Removed the old `canvas_to_ppm` and `test_rendering` functions from `src/main.c`. (`src/main.c`)

### Configuration Changes:

* Updated the default image dimensions and pixel sampling rate in `include/minirt.h` and `src/world/world.c`. (`include/minirt.h`, `src/world/world.c`) [[1]](diffhunk://#diff-aa8bff8e214ca5a9fcf7d483a0d202122869c9bec85eee174a3424323dfbc6edR34-R37) [[2]](diffhunk://#diff-de24d310b45ac493334b8c07d35e0aec6a983cbd03831191fa8e56c3a392de71L24-R24)

### Memory Leak Suppression:

* Added suppression rules for memory leaks related to the MLX library in `supp.supp`. (`supp.supp`)